### PR TITLE
Make sure .git exists in source directory

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -3949,7 +3949,8 @@ SYMBOL is as in `xref-find-definitions'."
 
 (defun radian-clone-emacs-source-maybe ()
   "Prompt user to clone Emacs source repository if needed."
-  (when (and (not (file-directory-p (expand-file-name ".git" source-directory)))
+  (when (and (not (file-directory-p 
+                   (expand-file-name ".git" source-directory)))
              (not (get-buffer "*clone-emacs-src*"))
              (yes-or-no-p "Clone Emacs source repository? "))
     (make-directory (file-name-directory source-directory) 'parents)

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -3949,7 +3949,7 @@ SYMBOL is as in `xref-find-definitions'."
 
 (defun radian-clone-emacs-source-maybe ()
   "Prompt user to clone Emacs source repository if needed."
-  (when (and (not (file-directory-p 
+  (when (and (not (file-directory-p
                    (expand-file-name ".git" source-directory)))
              (not (get-buffer "*clone-emacs-src*"))
              (yes-or-no-p "Clone Emacs source repository? "))

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -3949,7 +3949,7 @@ SYMBOL is as in `xref-find-definitions'."
 
 (defun radian-clone-emacs-source-maybe ()
   "Prompt user to clone Emacs source repository if needed."
-  (when (and (not (file-directory-p source-directory))
+  (when (and (not (file-directory-p (expand-file-name ".git" source-directory)))
              (not (get-buffer "*clone-emacs-src*"))
              (yes-or-no-p "Clone Emacs source repository? "))
     (make-directory (file-name-directory source-directory) 'parents)


### PR DESCRIPTION
If the checking out of emacs source is interrupted, an empty directory is left behind and subsequent attempts of getting the source are cancelled. This fix makes sure that a `.git` directory exists instead.