### PR TITLE
Add Vertico extensions to load path.

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -990,7 +990,16 @@ ourselves."
 ;; remaining candidates. This offers a significant improvement over
 ;; the default Emacs interface for candidate selection.
 (radian-use-package vertico
-  :straight (:host github :repo "minad/vertico")
+  :straight (:host github :repo "minad/vertico"
+             :files (:defaults "extensions/*")
+             :includes (vertico-buffer
+                        vertico-directory
+                        vertico-flat
+                        vertico-indexed
+                        vertico-mouse
+                        vertico-quick
+                        vertico-repeat
+                        vertico-reverse))
   :demand t
   :config
 


### PR DESCRIPTION
I wasn't able to setup vertico-directory without this. From https://github.com/radian-software/straight.el/issues/819#issuecomment-882039946. As far as I know, this doesn't actually enable these extensions. They must still be explicitly enabled. For what it's worth, I personally would prefer to see vertico-directory enabled by default by radian. I found the default Vertico experience unusable.