### PR TITLE
Enable vertico-directory.

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -1005,6 +1005,19 @@ ourselves."
 
   (vertico-mode +1)
 
+  ;; Enable `vertico-directory'. Commands for Ido-like directory navigation.
+  ;; About Vertico extensions: https://github.com/minad/vertico#extensions
+  (require 'vertico-directory)
+
+  (define-key vertico-map (kbd "RET")
+    #'vertico-directory-enter)
+  (define-key vertico-map (kbd "DEL")
+    #'vertico-directory-delete-char)
+  (define-key vertico-map (kbd "M-DEL")
+    #'vertico-directory-delete-word)
+
+  (add-hook 'rfn-eshadow-update-overlay-hook #'vertico-directory-tidy)
+
   (radian-defadvice radian--advice-vertico-select-first-candidate (&rest _)
     :after #'vertico--update-candidates
     "Select first candidate rather than prompt by default.

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -1001,20 +1001,13 @@ ourselves."
                         vertico-repeat
                         vertico-reverse))
   :demand t
+  :bind (:map vertico-map
+              ("RET" . #'vertico-directory-enter)
+              ("DEL" . #'vertico-directory-delete-char)
+              ("M-DEL" . #'vertico-directory-delete-word))
   :config
 
   (vertico-mode +1)
-
-  ;; Enable `vertico-directory'. Commands for Ido-like directory navigation.
-  ;; About Vertico extensions: https://github.com/minad/vertico#extensions
-  (require 'vertico-directory)
-
-  (define-key vertico-map (kbd "RET")
-    #'vertico-directory-enter)
-  (define-key vertico-map (kbd "DEL")
-    #'vertico-directory-delete-char)
-  (define-key vertico-map (kbd "M-DEL")
-    #'vertico-directory-delete-word)
 
   (add-hook 'rfn-eshadow-update-overlay-hook #'vertico-directory-tidy)
 


### PR DESCRIPTION
Follow-on from https://github.com/radian-software/radian/pull/514

My apologizes to the author of Vertico. I disabled vertico-directory so that I could tell that the the changes I made here worked when enabled. However, I did not get the same default behavior. I remember the selections were horizontal, and really difficult to navigate. This time though the selections were vertical, and navigation was just so-so. I still say vertico-diretory should be enabled by default as a former, happy Ido-vertical and Ido-everywhere user.