### PR TITLE
Add a compilation flag

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -76,6 +76,9 @@ Radian always loads the packages `use-package', `straight',
 `blackout', `bind-key' and `el-patch' even if they are members of
 this list.")
 
+(defvar radian-compiling nil
+  "Non-nil when Radian's make is being called.")
+
 (unless radian-org-enable-contrib
   (add-to-list 'radian-disabled-packages
                'org-contrib))

--- a/scripts/byte-compile.bash
+++ b/scripts/byte-compile.bash
@@ -5,6 +5,7 @@ set -o pipefail
 
 (emacs --batch \
        --eval "(setq straight-safe-mode t)"                  \
+       --eval "(setq radian-compiling t)"                    \
        --load "$HOME/.emacs.d/init.el"                       \
        --funcall radian-batch-byte-compile 2>&1              \
      | (grep -v "In toplevel form"                  || true) \


### PR DESCRIPTION
In my init file, I sometimes output some helpful messages (mostly diagnostics) which cause Radian's make file to fail since it considers any output in the compilation process an error.

There are two ways to solve this:
- Adding a flag (like I do in this pull request) and then testing for it in my config whenever I output a message in my init file (Note that testing for `byte-compile-current-file` doesn't help since the issue is with the emacs instance running the compilation function).
 
- A more elegant solution, I think, would be to run the emacs process in `byte-compile.bash` with `--no-local`. However, there are a couple issues with `--no-local` which make it unusable (at least for me). The first is that packages are automatically pruned (which can be fixed easily) and the other issue is that `--no-local` doesn't even run the `before-straight` hook which is necessary in my case to set the correct paths like `straight-*-dir` and `no-littering-*-directory`, `radian-disabled-packages` and `straight-recipe-overrides`. Perhaps `--no-local` or a similar flag should be defined so that `before-straight` is run but not `after-init`.
 