### PR TITLE
Fix compilation warnings on emacs 29.0.60

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -918,7 +918,7 @@ In particular, if you have an image on your system clipboard and
 you either yank or kill (as `save-interprogram-paste-before-kill'
 means Emacs will try to put the system clipboard contents into
 the kill ring when you kill something new), you'll get the
-message 'gui-get-selection: (error \"Selection owner couldn't
+message \\='gui-get-selection: (error \"Selection owner couldn't
 convert\" UTF8_STRING)'. Disable that."
   (radian--with-silent-message "Selection owner couldn't convert"
     (apply func args)))
@@ -2352,18 +2352,18 @@ set LSP configuration (see `lsp-python-ms')."
                    ;; `lsp-mode' doesn't support Elisp, so let's avoid
                    ;; triggering the autoload just for checking that, yes,
                    ;; there's nothing to do for the *scratch* buffer.
-                   #'emacs-lisp-mode
+                   'emacs-lisp-mode
                    ;; Disable for modes that we currently use a specialized
                    ;; framework for, until they are phased out in favor of
                    ;; LSP.
-                   #'clojure-mode
-                   #'ruby-mode
+                   'clojure-mode
+                   'ruby-mode
                    ;; Disable for modes with insufficiently mature
                    ;; language servers.
-                   #'terraform-mode
+                   'terraform-mode
                    ;; Weird error relating to toml lsp for some
                    ;; reason.
-                   #'makefile-mode))
+                   'makefile-mode))
         (lsp))))
 
   :config


### PR DESCRIPTION
This fixes a couple of warnings on emacs 29.0.60. The first is an unescaped single quotation.
The other warning come from `radian--lsp-enable` where using `#` issues a warning when the functions are not defined (they would be if the corresponding packages are disabled).

There is another deprecation warning for using `point-at-eol` which should be changed to `pos-eol`, but I don't know if you want to define this function in earlier versions of emacs or maybe use `compat`.