### PR TITLE
emacs 29 changes and change --no-local

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: [27, 28, 29]
+        emacs_version: [27, 28]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: [27, 28]
+        emacs_version: [27, 28, 29]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This has several changes which I found useful, but I am not sure which ones would be wanted by others, so I am creating this PR as draft.

- Use `compat` to avoid calling `point-at-eol` which is not available in emacs 29
- Repositories are only pruned when not compiling and when `--no-local` is not passed. Both of these modes are temporary and should not affect the state of radian.
- I changed `--no-local` to not call the hook `'after-init` rather than not load any local config. This is because local config (including `before-init`) might include path setting including for straight (my local config does this). Hence, running emacs without this pre-configuration would lead to unnecessary cloning of straight among other things. I am not sure if `--no-local` should be changed as I suggest here or a different flag should be defined.

