### PR TITLE
A couple of fixes

### DIFF
--- a/emacs/init.el
+++ b/emacs/init.el
@@ -51,7 +51,8 @@ loading the init-file twice if it were not for this variable.")
                        "but you are running Emacs %s")
                radian-minimum-emacs-version emacs-version)
 
-      (let* ((this-file (or user-init-file "~/.emacs.d/init.el"))
+      (let* ((this-file (or user-init-file
+                            (expand-file-name "init.el" user-emacs-directory)))
              (link-target
               ;; This function returns the target of the link. If the
               ;; init-file is not a symlink, then we abort.

--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -4447,8 +4447,10 @@ the problematic case.)"
   :config
 
   ;; Prevent annoying "Omitted N lines" messages when auto-reverting.
-  (setq dired-omit-verbose nil)
+  (setq dired-omit-verbose nil))
 
+(use-feature dired-aux
+  :config
   (radian-with-operating-system macOS
     (radian-defadvice radian--advice-dired-guess-open-on-macos
         (&rest _)

--- a/scripts/byte-compile.bash
+++ b/scripts/byte-compile.bash
@@ -4,9 +4,11 @@ set -e
 set -o pipefail
 
 (emacs --batch \
-       --eval "(setq straight-safe-mode t)"                  \
-       --eval "(setq radian-compiling t)"                    \
-       --load "$HOME/.emacs.d/init.el"                       \
+       --eval "(progn                                        \
+                (setq straight-safe-mode t                   \
+                      radian-compiling t)                    \
+                (load (expand-file-name \"init.el\"          \
+                      user-emacs-directory) nil t))"         \
        --funcall radian-batch-byte-compile 2>&1              \
      | (grep -v "In toplevel form"                  || true) \
      | (grep -v "In end of data"                    || true) \


### PR DESCRIPTION
This PR fixes two issues:

- `dired-aux` should be loaded before `dired-guess-default` is patched to avoid compilation issues.
- Various changes to make sure that `user-emacs-directory` is used when loading `init.el` to allow emacs configuration to be in `XDG_CONFIG_*` for example (I am trying to declutter my home directory).