### PR TITLE
Fix advice for elisp--company-doc-buffer

### DIFF
--- a/emacs/radian.el
+++ b/emacs/radian.el
@@ -3963,10 +3963,17 @@ bizarre reason."
         (func &rest args)
       :around #'elisp--company-doc-buffer
       "Cause `company' to use Helpful to show Elisp documentation."
-      (cl-letf (((symbol-function #'describe-function) #'helpful-function)
-                ((symbol-function #'describe-variable) #'helpful-variable)
-                ((symbol-function #'help-buffer) #'current-buffer))
-        (apply func args))))
+      (cl-letf* ((helpful-buffer nil)
+                 ((symbol-function #'describe-function)
+                  (lambda (&rest args)
+                    (apply 'helpful-function args)
+                    (setq helpful-buffer (current-buffer))))
+                 ((symbol-function #'describe-variable)
+                  (lambda (&rest args)
+                    (apply 'helpful-variable args)
+                    (setq helpful-buffer (current-buffer))))
+                 (buf (apply func args)))
+        (or helpful-buffer buf))))
 
   (radian-defadvice radian--advice-fill-elisp-docstrings-correctly (&rest _)
     :before-until #'fill-context-prefix


### PR DESCRIPTION
The advice `radian--advice-company-elisp-use-helpful` replaces `(help-buffer)` with `(current-buffer)` assuming that a helpful command will be called.

However, this is only true for functions and variables. If `elisp--company-doc-buffer` is called with a feature or a face, the current, unrelated, buffer is used when standard `help-*` commands are called, leading to the current buffer content being overwritten.

The change in the PR gets around that issue but not overriding `help-buffer`. The solution fixes the issue, but it still feels hacky and a better solution might be to patch `elisp--company-doc-buffer` instead.