### PR TITLE
Unfuck emacsql errors slightly

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ configuration, and optionally installing local configuration.
   time) `apt install watchexec-cli`
   * For LSP servers, refer to [`lsp-mode`
     documentation](https://emacs-lsp.github.io/lsp-mode/page/languages/)
+  * For Magit forge integration, `apt install libsqlite3-dev`
 * Zsh: `apt install zsh`
 * Tmux: `apt install tmux`
 * Git: `apt install git`


### PR DESCRIPTION
Error message from compiling the C module gets silently eaten by a containing `condition-case`, Magit falls back to legacy backend and prints a warning. The way this is written it's hard to improve the error handling. Add a quick hack to make sure the issue is at least displayed.